### PR TITLE
Fix template lookup path for Flask app

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,10 +2,26 @@ import os, uuid, threading, json
 from flask import Flask, request, jsonify, send_from_directory, render_template, make_response
 
 from .pipeline import run_pipeline, new_session_dir, write_json_atomic, progress_path, ffprobe_ok
-
-
 def create_app():
-    app = Flask(__name__, template_folder="templates", static_folder="static")
+    """Create and configure the Flask application.
+
+    The project keeps its ``templates`` and ``static`` directories at the
+    repository root rather than inside the ``app`` package.  When running the
+    application Flask would look for these directories relative to the package
+    and consequently fail to locate them, raising ``TemplateNotFound`` for
+    ``index.html``.
+
+    Determine the project root and point Flask at the correct directories so
+    that template rendering and static file serving work in both development and
+    production environments.
+    """
+
+    # Locate repository root (parent directory of this file's package)
+    root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    template_dir = os.path.join(root_dir, "templates")
+    static_dir = os.path.join(root_dir, "static")
+
+    app = Flask(__name__, template_folder=template_dir, static_folder=static_dir)
     app.config["UPLOAD_FOLDER"] = "/tmp/peakpilot"
     app.config["MAX_CONTENT_LENGTH"] = 512 * 1024 * 1024
     os.makedirs(app.config["UPLOAD_FOLDER"], exist_ok=True)

--- a/tests/test_index_page.py
+++ b/tests/test_index_page.py
@@ -1,0 +1,7 @@
+import pytest
+
+
+def test_index_page(client):
+    resp = client.get('/')
+    assert resp.status_code == 200
+    assert b'PeakPilot' in resp.data


### PR DESCRIPTION
## Summary
- point Flask to correct template and static directories at project root
- add regression test ensuring index page renders successfully

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689821fda99083298c66c4e95408ad94