### PR TITLE
feat: add drag-and-drop audio upload

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1,11 +1,15 @@
 :root{--bg:#0c0d10;--fg:#e6e7ea;--muted:#a9adba;--accent:#8be9fd;--glass:rgba(255,255,255,0.06);--card:rgba(255,255,255,0.08)}
 *{box-sizing:border-box}
+[hidden]{display:none !important}
 body.pp-dark{margin:0;background:radial-gradient(1200px 600px at 30% -10%,#171a22,transparent),linear-gradient(#0b0c0f,#0b0c0f);color:var(--fg);font:15px/1.5 Inter,system-ui,sans-serif}
 .pp-header{display:flex;align-items:center;gap:12px;padding:16px 20px;border-bottom:1px solid #141720;background:linear-gradient(180deg,#0f1116,#0b0c0f)}
 .pp-logo{height:28px}
 .pp-main{padding:20px;max-width:1100px;margin:0 auto}
 #upload-form{display:flex;gap:12px;align-items:center;margin-bottom:16px}
 #analyze-btn{background:var(--accent);border:none;color:#001018;padding:10px 14px;border-radius:10px;font-weight:700;cursor:pointer}
+.drop-area{flex:1;padding:20px;border:2px dashed #141720;border-radius:16px;background:var(--glass);text-align:center;cursor:pointer}
+.drop-area.hover{border-color:var(--accent);background:rgba(139,233,253,0.1)}
+.drop-area span{display:block;color:var(--muted)}
 .track-section{margin:18px 0;padding:14px;border:1px solid #141720;border-radius:16px;background:var(--glass);backdrop-filter:blur(10px)}
 .wf-row{display:grid;grid-template-columns:1fr auto;align-items:center;gap:8px}
 .wf{height:84px;border-radius:8px;background:#0f121a;border:1px solid #141720;overflow:hidden}

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -84,16 +84,50 @@ function updateButtons(activeId, playing){
 // Upload & polling
 const form = $('#upload-form');
 const fileInput = $('#file-input');
+const dropArea = $('#drop-area');
+const dropText = $('#drop-text');
+const analyzeBtn = $('#analyze-btn');
 const modal = $('#pp-modal');
 const bar = $('#pp-bar');
 const stageEl = $('#pp-stage');
 const flavorEl = $('#pp-flavor');
 const outputs = $('#outputs-section');
+modal.hidden = true;
 
 let session = null;
 let timer = null;
 let originalURL = null;
 let refI = -14;
+
+function setFile(file){
+  if (!file) return;
+  const dt = new DataTransfer();
+  dt.items.add(file);
+  fileInput.files = dt.files;
+  dropText.textContent = file.name;
+  analyzeBtn.disabled = false;
+}
+
+dropArea.addEventListener('click', ()=> fileInput.click());
+dropArea.addEventListener('dragover', (e)=>{ e.preventDefault(); dropArea.classList.add('hover'); });
+dropArea.addEventListener('dragleave', ()=> dropArea.classList.remove('hover'));
+dropArea.addEventListener('drop', (e)=>{
+  e.preventDefault();
+  dropArea.classList.remove('hover');
+  const file = e.dataTransfer.files?.[0];
+  setFile(file);
+});
+
+fileInput.addEventListener('change', ()=>{
+  const file = fileInput.files?.[0];
+  if (file){
+    dropText.textContent = file.name;
+    analyzeBtn.disabled = false;
+  } else {
+    dropText.textContent = 'Drag & drop audio here or click to browse';
+    analyzeBtn.disabled = true;
+  }
+});
 
 form.addEventListener('submit', async (e)=>{
   e.preventDefault();

--- a/templates/index.html
+++ b/templates/index.html
@@ -14,8 +14,11 @@
 
   <main class="pp-main">
     <form id="upload-form">
-      <input id="file-input" type="file" name="audio" accept="audio/*" required />
-      <button id="analyze-btn" type="submit">Analyze → Master</button>
+      <div id="drop-area" class="drop-area">
+        <span id="drop-text">Drag & drop audio here or click to browse</span>
+        <input id="file-input" type="file" name="audio" accept="audio/*" required hidden />
+      </div>
+      <button id="analyze-btn" type="submit" disabled>Analyze → Master</button>
     </form>
 
     <section id="original-section" class="track-section">


### PR DESCRIPTION
## Summary
- add drag & drop zone for audio uploads and disable analyze button until a file is chosen
- ensure analysis modal remains hidden until analyze runs and style drop area

## Testing
- `pytest`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68984a943a308329a447ab054f3df8e5