### PR TITLE
feat: add staged upload and gated dropzone

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1,0 +1,134 @@
+(() => {
+  const analyzeBtn = document.querySelector('#analyzeBtn');
+  const clearBtn = document.querySelector('#clearBtn');
+  const fileInput = document.querySelector('#fileInput');
+  const dropZone = document.querySelector('#dropZone');
+  const fileList = document.querySelector('#fileList');
+  const errorBox = document.querySelector('#inlineError');
+
+  const modal = document.getElementById('pp-modal');
+  const bar = document.getElementById('pp-bar');
+  const stageEl = document.getElementById('pp-stage');
+  const flavorEl = document.getElementById('pp-flavor');
+
+  const ALLOWED = ['wav','aiff','aif','flac','mp3'];
+  let fileQueue = []; // at most 1 file
+  let session = null;
+  let pollTimer = null;
+
+  const isAllowed = name => ALLOWED.includes((name.split('.').pop()||'').toLowerCase());
+
+  function renderList() {
+    fileList.innerHTML = '';
+    if (fileQueue.length === 0) return;
+    const f = fileQueue[0];
+    const el = document.createElement('div');
+    el.className = 'pp-filechip';
+    el.innerHTML = `\n      <div class="pp-filemeta">${f.name} <span aria-hidden="true">•</span> ${(f.size/1024/1024).toFixed(2)} MB</div>\n      <button class="pp-remove" aria-label="Remove file">✕</button>`;
+    el.querySelector('.pp-remove').addEventListener('click', () => { fileQueue = []; syncState(); });
+    fileList.appendChild(el);
+  }
+
+  function syncState() {
+    const ok = fileQueue.length === 1 && isAllowed(fileQueue[0].name);
+    analyzeBtn.disabled = !ok;
+    analyzeBtn.setAttribute('aria-disabled', String(!ok));
+    if (ok) errorBox.textContent = '';
+    renderList();
+  }
+
+  function setFiles(list) {
+    const arr = Array.from(list || []);
+    fileQueue = [];
+    if (arr.length) {
+      const f = arr[0];
+      if (!isAllowed(f.name)) {
+        errorBox.textContent = 'Unsupported format. Use WAV/AIFF/FLAC/MP3.';
+      } else {
+        fileQueue = [f];
+        errorBox.textContent = '';
+      }
+    }
+    syncState();
+  }
+
+  // DnD
+  dropZone.addEventListener('dragover', e => { e.preventDefault(); dropZone.classList.add('pp-dragover'); });
+  dropZone.addEventListener('dragleave', () => dropZone.classList.remove('pp-dragover'));
+  dropZone.addEventListener('drop', e => {
+    e.preventDefault();
+    dropZone.classList.remove('pp-dragover');
+    if (e.dataTransfer?.files?.length) setFiles(e.dataTransfer.files);
+  });
+  dropZone.addEventListener('click', () => fileInput.click());
+  fileInput.addEventListener('change', e => setFiles(e.target.files));
+
+  clearBtn.addEventListener('click', () => { fileQueue = []; fileInput.value=''; syncState(); });
+
+  function openAnalyzingModal() {
+    modal.hidden = false;
+    bar.classList.add('indeterminate');
+    bar.style.width = '0%';
+    stageEl.textContent = 'Starting…';
+    flavorEl.textContent = '';
+  }
+
+  async function pollProgress() {
+    if (!session) return;
+    try {
+      const r = await fetch(`/progress/${session}`, { cache:'no-store' });
+      if (!r.ok) return;
+      const p = await r.json();
+      if (typeof p.percent === 'number') {
+        bar.classList.remove('indeterminate');
+        bar.style.width = `${p.percent}%`;
+      }
+      stageEl.textContent = p.message || p.phase;
+      flavorEl.textContent = '';
+      if (p.done) {
+        clearInterval(pollTimer);
+      }
+    } catch (e) {
+      // silent
+    }
+  }
+
+  function beginPollingProgress() {
+    if (pollTimer) clearInterval(pollTimer);
+    pollTimer = setInterval(pollProgress, 1000);
+  }
+
+  analyzeBtn.addEventListener('click', async () => {
+    if (analyzeBtn.disabled) {
+      errorBox.textContent = 'Add an audio file to analyze.';
+      dropZone.classList.add('pp-dragover');
+      setTimeout(() => dropZone.classList.remove('pp-dragover'), 350);
+      return;
+    }
+
+    try {
+      const data = new FormData();
+      data.append('file', fileQueue[0], fileQueue[0].name);
+      const up = await fetch('/upload', { method: 'POST', body: data });
+      if (!up.ok) {
+        const j = await up.json().catch(()=>({}));
+        errorBox.textContent = j.error || 'Upload failed.';
+        return;
+      }
+
+      const res = await fetch('/start', { method: 'POST' });
+      if (!res.ok) {
+        const j = await res.json().catch(()=>({}));
+        errorBox.textContent = j.error || 'Server refused to start analysis.';
+        return;
+      }
+      const js = await res.json();
+      session = js.session;
+
+      openAnalyzingModal();
+      beginPollingProgress();
+    } catch (e) {
+      errorBox.textContent = 'Network error. Try again.';
+    }
+  });
+})();

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,25 @@
+:root{
+  --pp-border:#141720;
+  --pp-bg2: var(--glass);
+  --pp-accent: var(--accent);
+}
+.pp-uploader { display:grid; gap:12px; }
+.pp-dropzone {
+  border:2px dashed var(--pp-border, #444);
+  border-radius:16px; padding:28px; text-align:center;
+  background: var(--pp-bg2, rgba(255,255,255,0.02));
+  transition: border-color .15s, background .15s, transform .06s;
+}
+.pp-dropzone:focus { outline:2px solid var(--pp-accent, #7ef); outline-offset:4px; }
+.pp-dropzone.pp-dragover { border-color: var(--pp-accent, #7ef); background: rgba(126,239,255,0.06); transform: scale(1.01);}
+.pp-dropicon { font-size:2rem; margin-bottom:.25rem; opacity:.9; }
+.pp-droptitle { font-weight:600; font-size:1.1rem; }
+.pp-choosebtn { display:inline-block; padding:.5rem .9rem; border-radius:999px; border:1px solid var(--pp-border,#444); }
+.pp-note { font-size:.85rem; opacity:.8; margin-top:.4rem; }
+.pp-filelist { display:grid; gap:8px; }
+.pp-filechip { display:flex; align-items:center; justify-content:space-between; padding:.6rem .8rem; border:1px solid var(--pp-border,#444); border-radius:12px; }
+.pp-filemeta { font-size:.9rem; opacity:.9; }
+.pp-remove { border:none; background:transparent; cursor:pointer; }
+.pp-error { color: #f66; min-height:1.2em; }
+.pp-actions { display:flex; gap:10px; justify-content:flex-start; align-items:center; }
+.pp-primary[disabled] { opacity:.5; cursor:not-allowed; }

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>PeakPilot</title>
   <link rel="stylesheet" href="/static/css/app.css"/>
+  <link rel="stylesheet" href="/static/style.css"/>
 </head>
 <body class="pp-dark">
   <header class="pp-header">
@@ -13,13 +14,26 @@
   </header>
 
   <main class="pp-main">
-    <form id="upload-form">
-      <div id="drop-area" class="drop-area">
-        <span id="drop-text">Drag & drop audio here or click to browse</span>
-        <input id="file-input" type="file" name="audio" accept="audio/*" required hidden />
+    <section id="uploader" class="pp-uploader">
+      <div id="dropZone" class="pp-dropzone" tabindex="0" role="button" aria-label="Drop or choose audio file">
+        <div class="pp-dropicon" aria-hidden="true">🎵</div>
+        <div class="pp-droptitle">Drag & drop your mix</div>
+        <div class="pp-dropsub">or</div>
+        <label class="pp-choose">
+          <input id="fileInput" type="file" accept=".wav,.aiff,.aif,.flac,.mp3" hidden />
+          <span class="pp-choosebtn">Choose file</span>
+        </label>
+        <div class="pp-note">WAV / AIFF / FLAC / MP3 • up to 1 file</div>
       </div>
-      <button id="analyze-btn" type="submit" disabled>Analyze → Master</button>
-    </form>
+
+      <div id="fileList" class="pp-filelist" aria-live="polite"></div>
+      <div id="inlineError" class="pp-error" role="alert" aria-live="assertive"></div>
+
+      <div class="pp-actions">
+        <button id="analyzeBtn" disabled aria-disabled="true" class="pp-primary">Analyze</button>
+        <button id="clearBtn" class="pp-ghost" type="button">Clear</button>
+      </div>
+    </section>
 
     <section id="original-section" class="track-section">
       <h2>Original</h2>
@@ -52,7 +66,6 @@
     </div>
   </div>
 
-  <script src="/static/js/wavesurfer.min.js"></script>
-  <script src="/static/js/app.js"></script>
+  <script src="/static/app.js"></script>
 </body>
 </html>

--- a/tests/test_progress_error_lifecycle.py
+++ b/tests/test_progress_error_lifecycle.py
@@ -4,11 +4,14 @@ from time import sleep
 from app.__init__ import create_app
 
 
-def test_invalid_file_sets_error():
+def test_invalid_file_sets_error(tmp_path, monkeypatch):
+    monkeypatch.setenv('WORK_DIR', str(tmp_path/'work'))
     app = create_app()
     with app.test_client() as c:
-        data = { 'audio': ( io.BytesIO(b'not an audio'), 'bad.txt') }
-        r = c.post('/start', data=data, content_type='multipart/form-data')
+        data = { 'file': ( io.BytesIO(b'not an audio'), 'bad.wav') }
+        u = c.post('/upload', data=data, content_type='multipart/form-data')
+        assert u.status_code == 200
+        r = c.post('/start')
         assert r.status_code == 200
         session = r.get_json()['session']
         saw_error = False

--- a/tests/test_start_no_audio.py
+++ b/tests/test_start_no_audio.py
@@ -1,0 +1,10 @@
+from app.__init__ import create_app
+
+
+def test_start_without_audio_returns_400(tmp_path, monkeypatch):
+    monkeypatch.setenv('WORK_DIR', str(tmp_path/'work'))
+    app = create_app()
+    with app.test_client() as client:
+        rv = client.post('/start')
+        assert rv.status_code == 400
+        assert 'NO_AUDIO' in rv.get_json().get('error', '')

--- a/tests/test_start_progress_smoke.py
+++ b/tests/test_start_progress_smoke.py
@@ -15,11 +15,14 @@ def _sine_wav_bytes(sr=48000, dur=0.8, freq=440.0):
     return buf
 
 
-def test_start_and_poll_progress():
+def test_start_and_poll_progress(tmp_path, monkeypatch):
+    monkeypatch.setenv('WORK_DIR', str(tmp_path/'work'))
     app = create_app()
     with app.test_client() as c:
-        data = { 'audio': ( _sine_wav_bytes(), 'test.wav') }
-        r = c.post('/start', data=data, content_type='multipart/form-data')
+        data = { 'file': ( _sine_wav_bytes(), 'test.wav') }
+        u = c.post('/upload', data=data, content_type='multipart/form-data')
+        assert u.status_code == 200
+        r = c.post('/start')
         assert r.status_code == 200
         session = r.get_json()['session']
         advanced = False


### PR DESCRIPTION
## Summary
- add Clideo-style drag-and-drop uploader with clear button and inline errors
- introduce `/upload` endpoint and harden `/start` to require staged audio
- add regression tests for missing audio and update start tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68984d933a40832994d3499cef8c7374