### PR TITLE
Resolve default work directory permission issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ pinned: false
 ---
 
 Notes
-The server writes incremental progress and metrics to /tmp/peakpilot/<session>/progress.json. The UI polls /progress/<session> every second.
+The server writes session data under a configurable work directory (env `WORK_DIR`, default `/tmp/peakpilot`). Progress and metrics are stored in `<work>/<session>/progress.json` and the UI polls `/progress/<session>` every second.
 
 session.json includes version, selected preset, metrics, timeline arrays, AI adjustment info, and output checksums. It’s included in the ZIP and also separately downloadable.
 

--- a/tests/test_workdir_resolution.py
+++ b/tests/test_workdir_resolution.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+import shutil
+
+from app.__init__ import create_app
+
+
+def test_default_workdir(monkeypatch):
+    monkeypatch.delenv('WORK_DIR', raising=False)
+    app = create_app()
+    work = Path(app.config['WORK_DIR'])
+    assert work == Path('/tmp/peakpilot')
+    assert work.exists()
+    shutil.rmtree(work)
+
+
+def test_relative_workdir(monkeypatch):
+    monkeypatch.delenv('WORK_DIR', raising=False)
+    monkeypatch.setenv('WORK_DIR', 'relwork')
+    app = create_app()
+    work = Path(app.config['WORK_DIR'])
+    expected = Path(__file__).resolve().parent.parent / 'relwork'
+    assert work == expected
+    assert work.exists()
+    shutil.rmtree(work)


### PR DESCRIPTION
## Summary
- Ensure working directory defaults to `/tmp/peakpilot` and is configurable via `WORK_DIR`
- Guard directory creation with better error handling
- Document work directory behavior and add tests verifying resolution

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68984fb08f5883298932cf73c03444cf