### PR TITLE
Refine analyze UI and header styling

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -31,7 +31,6 @@
 
   function syncState() {
     const ok = fileQueue.length === 1 && isAllowed(fileQueue[0].name);
-    analyzeBtn.disabled = !ok;
     analyzeBtn.setAttribute('aria-disabled', String(!ok));
     if (ok) errorBox.textContent = '';
     renderList();
@@ -99,8 +98,8 @@
   }
 
   analyzeBtn.addEventListener('click', async () => {
-    if (analyzeBtn.disabled) {
-      errorBox.textContent = 'Add an audio file to analyze.';
+    if (analyzeBtn.getAttribute('aria-disabled') === 'true') {
+      errorBox.textContent = 'NO_AUDIO: Upload an audio file before analyzing.';
       dropZone.classList.add('pp-dragover');
       setTimeout(() => dropZone.classList.remove('pp-dragover'), 350);
       return;

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -3,7 +3,8 @@
 [hidden]{display:none !important}
 body.pp-dark{margin:0;background:radial-gradient(1200px 600px at 30% -10%,#171a22,transparent),linear-gradient(#0b0c0f,#0b0c0f);color:var(--fg);font:15px/1.5 Inter,system-ui,sans-serif}
 .pp-header{display:flex;align-items:center;gap:12px;padding:16px 20px;border-bottom:1px solid #141720;background:linear-gradient(180deg,#0f1116,#0b0c0f)}
-.pp-logo{height:28px}
+.pp-header h1{margin:0;font-size:2rem;line-height:1}
+.pp-logo{height:2rem}
 .pp-main{padding:20px;max-width:1100px;margin:0 auto}
 #upload-form{display:flex;gap:12px;align-items:center;margin-bottom:16px}
 #analyze-btn{background:var(--accent);border:none;color:#001018;padding:10px 14px;border-radius:10px;font-weight:700;cursor:pointer}

--- a/static/style.css
+++ b/static/style.css
@@ -22,4 +22,25 @@
 .pp-remove { border:none; background:transparent; cursor:pointer; }
 .pp-error { color: #f66; min-height:1.2em; }
 .pp-actions { display:flex; gap:10px; justify-content:flex-start; align-items:center; }
-.pp-primary[disabled] { opacity:.5; cursor:not-allowed; }
+.pp-primary {
+  padding:.6rem 1.2rem;
+  border-radius:12px;
+  border:none;
+  background:var(--pp-accent, #7ef);
+  color:#001018;
+  font-weight:600;
+  cursor:pointer;
+}
+.pp-primary[aria-disabled="true"] {
+  opacity:.5;
+  cursor:not-allowed;
+}
+
+.pp-ghost {
+  padding:.6rem 1.2rem;
+  border-radius:12px;
+  border:1px solid var(--pp-border,#444);
+  background:transparent;
+  color:var(--fg,#fff);
+  cursor:pointer;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -30,7 +30,7 @@
       <div id="inlineError" class="pp-error" role="alert" aria-live="assertive"></div>
 
       <div class="pp-actions">
-        <button id="analyzeBtn" disabled aria-disabled="true" class="pp-primary">Analyze</button>
+        <button id="analyzeBtn" aria-disabled="true" class="pp-primary" type="button">Analyze</button>
         <button id="clearBtn" class="pp-ghost" type="button">Clear</button>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- align header logo height with heading size and reset heading margins
- style Analyze and Clear buttons to match project design
- allow Analyze button to show "NO_AUDIO" message via aria-disabled state

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689852aaef848329957393b94af3b24a