### PR TITLE
feat: show upload progress and modal

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -18,7 +18,10 @@
 .pp-note { font-size:.85rem; opacity:.8; margin-top:.4rem; }
 .pp-filelist { display:grid; gap:8px; }
 .pp-filechip { display:flex; align-items:center; justify-content:space-between; padding:.6rem .8rem; border:1px solid var(--pp-border,#444); border-radius:12px; }
+.pp-fileinfo { flex:1; display:flex; flex-direction:column; gap:4px; }
 .pp-filemeta { font-size:.9rem; opacity:.9; }
+.pp-fileprog { height:4px; background:var(--pp-border,#444); border-radius:2px; overflow:hidden; }
+.pp-fileprog .bar { height:100%; width:0%; background:var(--pp-accent,#7ef); }
 .pp-remove { border:none; background:transparent; cursor:pointer; }
 .pp-error { color: #f66; min-height:1.2em; }
 .pp-actions { display:flex; gap:10px; justify-content:flex-start; align-items:center; }


### PR DESCRIPTION
## Summary
- display per-file upload progress bar in uploader chip
- open analyzing modal immediately and show upload progress
- style uploader chip progress bar

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689856ac50a483298260a59c049e667e