### PR TITLE
feat: redesign analyzing modal orb animation

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -59,9 +59,54 @@ body{margin:0;background:var(--bg);color:var(--text);font-family:ui-sans-serif,s
 /* modal */
 .modal{position:fixed;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.75);z-index:1000}
 .modal.hidden{display:none}
-.modal-inner{text-align:center}
-.orb-hero{display:flex;justify-content:center;align-items:center;margin:20px 0}
-#orb{width:160px;height:160px;display:block}
-.orb-fallback{width:120px;height:120px;border-radius:50%;background:radial-gradient(closest-side,rgba(31,241,233,.8),rgba(31,241,233,.25) 60%,rgba(31,241,233,0) 72%);animation:orbBreath 4.6s ease-in-out infinite;filter:drop-shadow(0 0 18px rgba(31,241,233,.45)) drop-shadow(0 0 36px rgba(31,241,233,.25))}
-@keyframes orbBreath{0%{transform:scale(.96);filter:drop-shadow(0 0 10px rgba(31,241,233,.35))}50%{transform:scale(1.04);filter:drop-shadow(0 0 26px rgba(31,241,233,.7))}100%{transform:scale(.96);filter:drop-shadow(0 0 10px rgba(31,241,233,.35))}}
-@keyframes indet{0%{left:-40%;}50%{left:20%;}100%{left:100%;}}
+
+/* Modal layout */
+.pp-modal.analyzing{
+  display:grid;
+  place-items:center;
+  gap:14px;
+  padding:16px 18px 20px;
+  max-width:420px;
+  margin:0 auto;
+  text-align:center;
+}
+
+/* Heading */
+#pp-analyze-title{
+  font-size:1.1rem;
+  letter-spacing:0.3px;
+  margin:2px 0 4px 0;
+}
+
+/* Orb block */
+.orb-hero{
+  position:relative;
+  width:160px;height:160px;
+  display:grid;place-items:center;
+  margin:0;
+}
+.orb-hero canvas#orb{display:block;}
+.orb-hero .orb-fallback{display:none;}
+
+/* Progress + message positioning */
+.pp-progress{
+  width:100%;
+  height:8px;
+  background:rgba(255,255,255,0.10);
+  border-radius:999px;
+  overflow:hidden;
+}
+.pp-progress .bar{
+  height:100%;
+  width:0%;
+  transition:width .18s ease;
+  background:linear-gradient(90deg, rgba(80,180,255,.95), rgba(120,255,220,.95));
+}
+.pp-state{
+  margin:2px 0 0 0;
+  font-size:.95rem;
+  opacity:.9;
+}
+
+/* High-DPI crispness hint for the canvas area (no blur around edges) */
+.orb-hero{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;}

--- a/templates/index.html
+++ b/templates/index.html
@@ -118,20 +118,16 @@
       </div>
 
     <div id="modal" class="modal hidden">
-      <div class="modal-inner card subtle">
+      <div class="pp-modal analyzing" role="dialog" aria-modal="true" aria-labelledby="pp-analyze-title">
+        <h2 id="pp-analyze-title">Analyzing...</h2>
         <div class="orb-hero">
-          <canvas id="orb" width="160" height="160"></canvas>
+          <canvas id="orb" width="320" height="320" style="width:160px;height:160px"></canvas>
           <div class="orb-fallback" aria-hidden="true"></div>
         </div>
-        <p class="tiny muted">Your master preview will be ready shortly and adjustments can be made to taste afterwards.</p>
-        <div id="progressWrap" class="progress-wrap">
-          <div class="progress-label">
-            <span id="phase">Starting…</span>
-            <span id="percent"></span>
-          </div>
-          <div class="progressbar"><div id="bar" class="indeterminate"></div></div>
-          <ul id="messages" class="messages"></ul>
+        <div class="pp-progress">
+          <div class="bar" style="width:0%"></div>
         </div>
+        <p id="pp-state" class="pp-state" aria-live="polite">Starting…</p>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- replace analyze modal markup with single canvas orb and progress bar
- add CSS for centered layout and transparent orb
- introduce OrbAnimator with waveform particles and singleton lifecycle

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68986ada963c83299dbdc10b2338657c