### PR TITLE
feat: add per-master progress updates

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -46,6 +46,8 @@ def create_app():
         f.save(src_path)
 
         seed = {
+            "pct": 0,
+            "status": "starting",
             "percent": 0,
             "phase": "starting",
             "message": "Starting…",
@@ -67,6 +69,12 @@ def create_app():
                 },
             },
             "timeline": {"sec": [], "short_term": [], "tp_flags": []},
+            "masters": {
+                "club": {"state": "queued", "pct": 0, "message": ""},
+                "stream": {"state": "queued", "pct": 0, "message": ""},
+                "unlimited": {"state": "queued", "pct": 0, "message": ""},
+                "custom": {"state": "queued", "pct": 0, "message": ""},
+            },
         }
         write_json_atomic(progress_path(sess_dir), seed)
 
@@ -85,11 +93,19 @@ def create_app():
             resp = make_response(
                 json.dumps(
                     {
+                        "pct": 0,
+                        "status": "starting",
                         "percent": 0,
                         "phase": "starting",
                         "message": "Starting…",
                         "done": False,
                         "error": None,
+                        "masters": {
+                            "club": {"state": "queued", "pct": 0, "message": ""},
+                            "stream": {"state": "queued", "pct": 0, "message": ""},
+                            "unlimited": {"state": "queued", "pct": 0, "message": ""},
+                            "custom": {"state": "queued", "pct": 0, "message": ""},
+                        },
                     }
                 ),
                 200,

--- a/app/engine/mastering.py
+++ b/app/engine/mastering.py
@@ -1,0 +1,63 @@
+import os
+import subprocess
+import time
+from pathlib import Path
+from typing import Callable, List
+
+import soundfile as sf
+
+from ..pipeline import update_progress
+
+
+def probe_duration_seconds(path: str) -> float:
+    """Return duration of ``path`` in seconds using ``soundfile``."""
+    with sf.SoundFile(path) as f:
+        return f.frames / f.samplerate
+
+
+def run_ffmpeg_with_progress(args: List[str], duration_s: float, update: Callable[[int], None], cwd: str | None = None):
+    """Run ffmpeg with ``-progress`` and forward percentage to ``update``."""
+    args = list(args)
+    args[-1:-1] = ["-progress", "pipe:1", "-nostats"]
+    proc = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=cwd, text=True, bufsize=1)
+    last_pct = -1
+    try:
+        while True:
+            line = proc.stdout.readline()
+            if not line:
+                if proc.poll() is not None:
+                    break
+                time.sleep(0.05)
+                continue
+            if line.startswith("out_time_ms="):
+                ms = int(line.split("=", 1)[1].strip() or 0)
+                pct = int(min(99, (ms / 1_000_000.0) / max(0.001, duration_s) * 100))
+                if pct != last_pct:
+                    last_pct = pct
+                    update(pct)
+    finally:
+        proc.wait()
+    if proc.returncode != 0:
+        err = proc.stderr.read() if proc.stderr else ""
+        raise RuntimeError(f"ffmpeg failed: {err[-800:]}")
+
+
+def _render_master(target: str, in_path: Path, out_path: Path, args_for_ffmpeg: List[str], masters: dict, sess_dir: str):
+    """Render a single master with progress updates."""
+    dur = probe_duration_seconds(str(in_path))
+    masters[target].update({"state": "rendering", "pct": 0, "message": "Rendering..."})
+    update_progress(sess_dir, masters={target: masters[target]})
+
+    def onp(pct: int):
+        masters[target].update({"pct": pct})
+        update_progress(sess_dir, masters={target: masters[target]})
+
+    part = out_path.with_suffix(out_path.suffix + ".part")
+    args = args_for_ffmpeg[:-1] + [str(part)]
+    run_ffmpeg_with_progress(args, dur, onp)
+    masters[target].update({"state": "finalizing", "message": "Finalizing..."})
+    update_progress(sess_dir, masters={target: masters[target]})
+    os.replace(part, out_path)
+    masters[target].update({"state": "done", "pct": 100, "message": "Ready"})
+    update_progress(sess_dir, masters={target: masters[target]})
+

--- a/static/css/results.css
+++ b/static/css/results.css
@@ -154,3 +154,12 @@
 .pp-dl:hover {
   text-decoration: underline;
 }
+
+.pp-statepill { display:inline-block; padding:2px 8px; border-radius:999px; font-size:.75rem; margin:4px 0 8px; border:1px solid var(--pp-border); }
+.pp-statepill[data-state="queued"]     { color:#bcd; }
+.pp-statepill[data-state="rendering"]  { color:#def; }
+.pp-statepill[data-state="finalizing"] { color:#def; }
+.pp-statepill[data-state="done"]       { color:#8ff; border-color:rgba(120,255,220,.35); box-shadow:0 0 12px rgba(120,255,220,.15) inset; }
+.pp-statepill[data-state="error"]      { color:#f99; border-color:rgba(255,120,120,.4); }
+
+.pp-dl[aria-disabled="true"] { pointer-events:none; opacity:.5; }


### PR DESCRIPTION
## Summary
- track progress for each master target and stream ffmpeg progress
- expose per-master rendering status to the frontend and enable controls when ready
- style state pills and disabled downloads for clearer feedback

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898b1d782788329912460153c0a2b7f