### PR TITLE
Ensure stereo previews and streaming playback

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,9 +1,9 @@
 import os, uuid, threading, json
 from flask import Flask, request, jsonify, render_template, make_response, send_file
 from pathlib import Path
-import subprocess, shutil
+import shutil
 
-from .pipeline import run_pipeline, new_session_dir, write_json_atomic, progress_path, ffprobe_ok
+from .pipeline import run_pipeline, new_session_dir, write_json_atomic, progress_path, ffprobe_ok, make_preview
 def create_app():
     """Create and configure the Flask application.
 
@@ -47,22 +47,8 @@ def create_app():
         src_path = os.path.join(sess_dir, "upload")
         f.save(src_path)
 
-        def make_input_preview(src: Path, dest: Path):
-            dest.parent.mkdir(parents=True, exist_ok=True)
-            subprocess.run([
-                "ffmpeg","-nostdin","-hide_banner","-y",
-                "-i", str(src),
-                "-ar","48000", "-c:a","pcm_s16le",
-                "-metadata", "encoded_by=PeakPilot",
-                "-metadata", "software=PeakPilot",
-                "-metadata", "comment=Mastered by PeakPilot",
-                "-metadata", "IENG=PeakPilot",
-                "-metadata", "ICMT=Mastered by PeakPilot",
-                str(dest)
-            ], check=True)
-
         try:
-            make_input_preview(Path(src_path), Path(sess_dir) / "input_preview.wav")
+            make_preview(Path(src_path), Path(sess_dir) / "input_preview.wav", sr=48000, stereo=True)
         except Exception:
             shutil.copyfile(src_path, os.path.join(sess_dir, "input_preview.wav"))
 

--- a/app/routes/stream.py
+++ b/app/routes/stream.py
@@ -1,6 +1,5 @@
 from flask import Blueprint, current_app, request, abort, Response
 from pathlib import Path
-import mimetypes
 import os
 
 from app.util_fs import session_root
@@ -31,11 +30,10 @@ def stream(session, key):
     p = root / key
     if not p.exists() or p.is_dir():
         abort(404)
-    mimetype = mimetypes.guess_type(p.name)[0] or "application/octet-stream"
     code, chunk, start, end, size = _open_range(p, request.headers.get("Range"))
     headers = {
         "Accept-Ranges": "bytes",
-        "Content-Type": mimetype,
+        "Content-Type": "audio/wav",
         "Cache-Control": "no-store, no-cache, must-revalidate, max-age=0",
     }
     if code == 206:

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -216,7 +216,6 @@ async function poll(url, originalBlobUrl, session){
           window.renderUploadedAudioCanvas(session);
         }
         const s = window.PeakPilot.session;
-        const base = `/download/${s}/`;
         if (typeof renderMasteringResultsInHero === 'function') {
           renderMasteringResultsInHero(s, [
             {
@@ -244,7 +243,8 @@ async function poll(url, originalBlobUrl, session){
           updateMasterCardsProgress(j);
         }
         if (window.drawPeakHighlightsOnOriginal){
-          fetch(base + encodeURIComponent("input_preview.wav")).then(r=>r.arrayBuffer()).then(ab=> window.PeakPilot.getAC().decodeAudioData(ab)).then(buf=> window.drawPeakHighlightsOnOriginal(loudCanvas, buf, -1.0)).catch(()=>{});
+          const pv = `/stream/${s}/` + encodeURIComponent("input_preview.wav");
+          fetch(pv).then(r=>r.arrayBuffer()).then(ab=> window.PeakPilot.getAC().decodeAudioData(ab)).then(buf=> window.drawPeakHighlightsOnOriginal(loudCanvas, buf, -1.0)).catch(()=>{});
         }
         const preTech = document.getElementById('preTech');
         if(preTech){

--- a/static/js/uploaded-canvas.js
+++ b/static/js/uploaded-canvas.js
@@ -67,7 +67,7 @@
     if(!host) return;
     const mount = document.createElement("div");
     host.innerHTML=""; host.appendChild(mount);
-    const url = `/download/${session}/input_preview.wav`;
+    const url = `/stream/${session}/input_preview.wav`;
     new SimpleWave({ mount, url });
   };
 })();


### PR DESCRIPTION
## Summary
- Replace preview generator with atomic WAV helper that forces 16-bit stereo output
- Force stereo encoding for all masters and stream previews; add preview streaming URLs across frontend
- Serve preview streams with proper audio/wav MIME and range support

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899009560648329a376572c3536f0b8