### PR TITLE
Finalize mastering session and tolerant streaming route

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -200,50 +200,53 @@ async function poll(url, originalBlobUrl, session){
           window.renderUploadedAudioCanvas(session);
         }
         const s = window.PeakPilot.session;
+        const baseStream = `/stream/${s}/`;
+        const baseDown   = `/download/${s}/`;
+        const previews = {
+          club:      baseStream + encodeURIComponent('club_master_preview.wav'),
+          streaming: baseStream + encodeURIComponent('stream_master_preview.wav'),
+          unlimited: baseStream + encodeURIComponent('premaster_unlimited_preview.wav'),
+          original:  baseStream + encodeURIComponent('input_preview.wav'),
+        };
+        const metrics = j?.metrics || {};
+        const ready   = !!j?.downloads_ready;
         if (typeof renderMasteringResultsInHero === 'function') {
-          const base = `/stream/${s}/`;
-          const jm = j?.metrics || {};
           renderMasteringResultsInHero(s, [
             {
               id: "club",
               title: "Club (48k/24, target −7.2 LUFS, −0.8 dBTP)",
-              wavKey: "club_master.wav",
-              infoKey: "ClubMaster_24b_48k_INFO.txt",
-              processedUrl: base + encodeURIComponent("club_master.wav"),
-              metrics: { input: jm.input || {}, output: jm.club || {} }
+              processedUrl: previews.club,
+              downloadWav:  ready ? baseDown + encodeURIComponent('club_master.wav') : null,
+              downloadInfo: ready ? baseDown + encodeURIComponent('ClubMaster_24b_48k_INFO.txt') : null,
+              metrics: { input: metrics.input || {}, output: metrics.club || {} }
             },
             {
               id: "streaming",
               title: "Streaming (44.1k/24, target −9.5 LUFS, −1.0 dBTP)",
-              wavKey: "stream_master.wav",
-              infoKey: "StreamingMaster_24b_44k1_INFO.txt",
-              processedUrl: base + encodeURIComponent("stream_master.wav"),
-              metrics: { input: jm.input || {}, output: jm.streaming || {} }
+              processedUrl: previews.streaming,
+              downloadWav:  ready ? baseDown + encodeURIComponent('stream_master.wav') : null,
+              downloadInfo: ready ? baseDown + encodeURIComponent('StreamingMaster_24b_44k1_INFO.txt') : null,
+              metrics: { input: metrics.input || {}, output: metrics.streaming || {} }
             },
             {
               id: "unlimited",
               title: "Unlimited Premaster (48k/24, peak −6 dBFS)",
-              wavKey: "premaster_unlimited.wav",
-              infoKey: "UnlimitedPremaster_24b_48k_INFO.txt",
-              processedUrl: base + encodeURIComponent("premaster_unlimited.wav"),
-              metrics: { input: jm.input || {}, output: jm.unlimited || {} }
+              processedUrl: previews.unlimited,
+              downloadWav:  ready ? baseDown + encodeURIComponent('premaster_unlimited.wav') : null,
+              downloadInfo: ready ? baseDown + encodeURIComponent('UnlimitedPremaster_24b_48k_INFO.txt') : null,
+              metrics: { input: metrics.input || {}, output: metrics.unlimited || {} }
             }
           ], { showCustom: false });
         }
         try {
           const gains = setABGains(j);
-          const base = `/stream/${s}/`;
-          abOrig?.addEventListener('click', () =>
-            loadIntoWave(base + encodeURIComponent('input_preview.wav'), 'Original (gain-matched)', gains.original));
-          pvClub?.addEventListener('click', () =>
-            loadIntoWave(base + encodeURIComponent('club_master.wav'), 'Club (gain-matched)', gains.club));
-          pvStreaming?.addEventListener('click', () =>
-            loadIntoWave(base + encodeURIComponent('stream_master.wav'), 'Streaming (gain-matched)', gains.streaming));
-          pvPremaster?.addEventListener('click', () =>
-            loadIntoWave(base + encodeURIComponent('premaster_unlimited.wav'), 'Unlimited (gain-matched)', gains.premaster));
+          abOrig?.addEventListener('click', () => loadIntoWave(previews.original,  'Original (gain-matched)', gains.original));
+          pvClub?.addEventListener('click', () => loadIntoWave(previews.club,      'Club (gain-matched)',     gains.club));
+          pvStreaming?.addEventListener('click', () => loadIntoWave(previews.streaming,'Streaming (gain-matched)', gains.streaming));
+          pvPremaster?.addEventListener('click', () => loadIntoWave(previews.unlimited,'Unlimited (gain-matched)', gains.premaster));
         } catch {}
         if (window.drawPeakHighlightsOnOriginal){
-          const pv = `/stream/${s}/` + encodeURIComponent("input_preview.wav");
+          const pv = previews.original;
           fetch(pv).then(r=>r.arrayBuffer()).then(ab=> window.PeakPilot.getAC().decodeAudioData(ab)).then(buf=> window.drawPeakHighlightsOnOriginal(loudCanvas, buf, -1.0)).catch(()=>{});
         }
         const preTech = document.getElementById('preTech');

--- a/static/js/results.js
+++ b/static/js/results.js
@@ -211,19 +211,26 @@
 
   function metricsTable(cfg){
     const m = cfg.metrics || {};
-    const wrap = document.createElement('div'); wrap.className = 'pp-metrics';
-    function fmtNum(v){ return (v === null || v === undefined) ? '—' : Number(v).toFixed(2); }
-    function row(label,a,b){ return `<div class="mrow"><span>${label}</span><span>${fmtNum(a)}</span><span>${fmtNum(b)}</span></div>`; }
-    let html = '<div class="mrow"><span></span><span>Input</span><span>Output</span></div>';
     if (cfg.id === 'unlimited') {
-      html += row('Peak dBFS', m.input?.peak_dbfs, m.output?.peak_dbfs);
-    } else {
-      html += row('LUFS‑I', m.input?.lufs_integrated, m.output?.lufs_integrated);
-      html += row('TP (dBTP)', m.input?.true_peak_db, m.output?.true_peak_db);
-      html += row('LRA (LU)', m.input?.lra, m.output?.lra);
+      return rows([[
+        'Peak dBFS',
+        fmt(m.input?.peak_dbfs),
+        fmt(m.output?.peak_dbfs)
+      ]]);
     }
-    wrap.innerHTML = html;
-    return wrap;
+    return rows([
+      ['LUFS-I',  fmt(m.input?.lufs_integrated), fmt(m.output?.lufs_integrated)],
+      ['TP (dBTP)', fmt(m.input?.true_peak_db),  fmt(m.output?.true_peak_db)],
+      ['LRA (LU)', fmt(m.input?.lra),            fmt(m.output?.lra)],
+    ]);
+
+    function fmt(v){ return v==null ? '—' : Number(v).toFixed(2); }
+    function rows(r){
+      const wrap = document.createElement('div'); wrap.className = 'pp-metrics';
+      const head = '<div class="mrow"><span></span><span>Input</span><span>Output</span></div>';
+      wrap.innerHTML = head + r.map(([k,a,b]) => `<div class="mrow"><span>${k}</span><span>${a}</span><span>${b}</span></div>`).join('');
+      return wrap;
+    }
   }
 
   function buildCard(session, cfg) {
@@ -247,8 +254,18 @@
     art.appendChild(metricsTable(cfg));
 
     const downloads = document.createElement('div'); downloads.className = 'pp-downloads';
-    const wav = document.createElement('a'); wav.className = 'pp-dl'; wav.href = `/download/${session}/${encodeURIComponent(cfg.wavKey)}`; wav.appendChild(iconDownload()); wav.appendChild(document.createTextNode(' Download WAV'));
-    const info = document.createElement('a'); info.className = 'pp-dl'; info.href = `/download/${session}/${encodeURIComponent(cfg.infoKey)}`; info.appendChild(iconDownload()); info.appendChild(document.createTextNode(' Download INFO'));
+    const wav = document.createElement('a'); wav.className = 'pp-dl'; wav.appendChild(iconDownload()); wav.appendChild(document.createTextNode(' Download WAV'));
+    const info = document.createElement('a'); info.className = 'pp-dl'; info.appendChild(iconDownload()); info.appendChild(document.createTextNode(' Download INFO'));
+    if (cfg.downloadWav) {
+      wav.href = cfg.downloadWav;
+    } else {
+      wav.setAttribute('aria-disabled','true');
+    }
+    if (cfg.downloadInfo) {
+      info.href = cfg.downloadInfo;
+    } else {
+      info.setAttribute('aria-disabled','true');
+    }
     downloads.appendChild(wav); downloads.appendChild(info); art.appendChild(downloads);
 
     new WaveformPlayer(btn, canvas, cfg.processedUrl);


### PR DESCRIPTION
## Summary
- Add `finalize_session` helper to rename previews, build manifest, and report metrics
- Allow `/stream` to accept both manifest keys and direct filenames
- Render preview URLs, metrics, and gated downloads on the front-end

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899ac92ebac8329ab663c8d82da0645