### PR TITLE
Prefix masters/INFO with original filename; add SOURCE block; expose dynamic names to UI

### DIFF
--- a/tests/test_outputs_downloads.py
+++ b/tests/test_outputs_downloads.py
@@ -24,12 +24,12 @@ def test_outputs_downloadable(client, sine_file):
         manifest = json.load(fh)
     expected = [
         'input_preview.wav',
-        'club_master.wav',
-        'stream_master.wav',
-        'premaster_unlimited.wav',
-        'ClubMaster_24b_48k_INFO.txt',
-        'StreamingMaster_24b_44k1_INFO.txt',
-        'UnlimitedPremaster_24b_48k_INFO.txt'
+        'test__club_master.wav',
+        'test__stream_master.wav',
+        'test__premaster_unlimited.wav',
+        'test__ClubMaster_24b_48k_INFO.txt',
+        'test__StreamingMaster_24b_44k1_INFO.txt',
+        'test__UnlimitedPremaster_24b_48k_INFO.txt'
     ]
     for key in expected:
         assert key in manifest


### PR DESCRIPTION
## Summary
- capture and sanitize original upload name, storing stem in progress.json for later use
- build final master and INFO filenames from the original stem and include ffprobe-derived SOURCE data
- surface finalized filenames through progress.json so the UI links downloads dynamically

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899c529efcc832982a89f4bd1fa74cc